### PR TITLE
Added several fixes to the logic of adding/removing likes in a chat message

### DIFF
--- a/chat/src/main/java/greencity/dto/ChatMessageWithFileDto.java
+++ b/chat/src/main/java/greencity/dto/ChatMessageWithFileDto.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.Data;
 import java.time.ZonedDateTime;
+import java.util.Set;
 
 @Data
 @NoArgsConstructor
@@ -19,4 +20,5 @@ public class ChatMessageWithFileDto {
     private String fileName;
     private String fileType;
     private String fileUrl;
+    private Set<UserDto> likes;
 }

--- a/chat/src/main/java/greencity/dto/UserDto.java
+++ b/chat/src/main/java/greencity/dto/UserDto.java
@@ -1,0 +1,16 @@
+package greencity.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserDto {
+    private Long id;
+    private String name;
+    private String profilePicture;
+}

--- a/chat/src/main/java/greencity/entity/ChatMessage.java
+++ b/chat/src/main/java/greencity/entity/ChatMessage.java
@@ -1,18 +1,31 @@
 package greencity.entity;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Column;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.JoinColumn;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
 import java.time.ZonedDateTime;
+import java.util.HashSet;
 import java.util.List;
-import jakarta.persistence.*;
-import lombok.*;
+import java.util.Set;
 
 @Entity
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Setter
-@Getter
-@ToString
 @Table(name = "chat_messages")
 public class ChatMessage {
     @Id
@@ -42,4 +55,11 @@ public class ChatMessage {
 
     @Column(name = "file_url")
     private String fileUrl;
+
+    @ManyToMany
+    @JoinTable(
+        name = "message_like",
+        joinColumns = @JoinColumn(name = "message_id"),
+        inverseJoinColumns = @JoinColumn(name = "participant_id"))
+    private Set<Participant> likes = new HashSet<>();
 }

--- a/chat/src/main/java/greencity/mapping/ChatMessageWithFileDtoMapper.java
+++ b/chat/src/main/java/greencity/mapping/ChatMessageWithFileDtoMapper.java
@@ -1,10 +1,13 @@
 package greencity.mapping;
 
 import greencity.dto.ChatMessageWithFileDto;
+import greencity.dto.UserDto;
 import greencity.entity.ChatMessage;
+import greencity.entity.Participant;
 import org.modelmapper.AbstractConverter;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Component;
+import java.util.stream.Collectors;
 
 /**
  * Class that used by {@link ModelMapper} to map {@link ChatMessage} into
@@ -26,6 +29,18 @@ public class ChatMessageWithFileDtoMapper extends AbstractConverter<ChatMessage,
             .fileName(chatMessage.getFileName())
             .fileType(chatMessage.getFileType())
             .fileUrl(chatMessage.getFileUrl())
+            .likes(chatMessage.getLikes() == null ? null
+                : chatMessage.getLikes().stream()
+                    .map(this::convertParticipant)
+                    .collect(Collectors.toSet()))
+            .build();
+    }
+
+    private UserDto convertParticipant(Participant participant) {
+        return UserDto.builder()
+            .id(participant.getId())
+            .name(participant.getName())
+            .profilePicture(participant.getProfilePicture())
             .build();
     }
 }

--- a/chat/src/main/java/greencity/repository/ChatMessageRepo.java
+++ b/chat/src/main/java/greencity/repository/ChatMessageRepo.java
@@ -3,8 +3,10 @@ package greencity.repository;
 import greencity.entity.ChatMessage;
 import greencity.entity.ChatRoom;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -103,4 +105,8 @@ public interface ChatMessageRepo extends PagingAndSortingRepository<ChatMessage,
      * @return list of {@link ChatMessage}s from room
      */
     List<ChatMessage> getAllByRoomId(Long roomId);
+
+    @Override
+    @EntityGraph(attributePaths = {"likes", "room"})
+    Optional<ChatMessage> findById(Long id);
 }

--- a/chat/src/main/java/greencity/service/impl/ChatMessageServiceImpl.java
+++ b/chat/src/main/java/greencity/service/impl/ChatMessageServiceImpl.java
@@ -130,13 +130,10 @@ public class ChatMessageServiceImpl implements ChatMessageService {
         } else {
             chatMessageRepo.addLikeToMessage(messageLike.getMessageId(), messageLike.getParticipantId());
         }
-        Map<String, Object> headers = new HashMap<>();
-        headers.put(HEADER_UPDATE, new Object());
-        ChatMessage chatMessage = chatMessageRepo.findById(messageLike.getMessageId()).get();
-        ChatMessageDto chatMessageDto = modelMapper.map(chatMessage,
-            ChatMessageDto.class);
-        messagingTemplate.convertAndSend(
-            ROOM_LINK + chatMessage.getRoom().getId() + MESSAGE_LINK, chatMessageDto, headers);
+        ChatMessage chatMessage = chatMessageRepo.findById(messageLike.getMessageId())
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.CHAT_MESSAGE_NOT_FOUND_BY_ID
+                + messageLike.getMessageId()));
+        sendMessageInChatRoomWithHeader(modelMapper.map(chatMessage, ChatMessageWithFileDto.class), HEADER_UPDATE);
     }
 
     @Override

--- a/chat/src/test/java/greencity/mapping/ChatMessageDtoMapperTest.java
+++ b/chat/src/test/java/greencity/mapping/ChatMessageDtoMapperTest.java
@@ -23,7 +23,7 @@ class ChatMessageDtoMapperTest {
             ChatType.GROUP, null, null),
             new Participant(1L, "name", "asd@asd.asd", null,
                 null, UserStatus.ACTIVATED, Role.ROLE_USER, null),
-            "content", null, null, "fileName", "FILE", "fileUrl");
+            "content", null, null, "fileName", "FILE", "fileUrl", null);
         expected = new ChatMessageDto(1L, 1L, 1L, "content",
             null);
     }

--- a/chat/src/test/java/greencity/mapping/ChatMessageMapperTest.java
+++ b/chat/src/test/java/greencity/mapping/ChatMessageMapperTest.java
@@ -19,7 +19,7 @@ class ChatMessageMapperTest {
     void init() {
         expected = new ChatMessage(1L, ChatRoom.builder().id(1L).build(),
             Participant.builder().id(1L).build(),
-            "content", ZonedDateTime.now(), null, null, null, null);
+            "content", ZonedDateTime.now(), null, null, null, null, null);
         chatMessageDto = new ChatMessageDto(1L, 1L, 1L, "content",
             null);
     }

--- a/chat/src/test/java/greencity/mapping/ChatMessageWithFileDtoMapperTest.java
+++ b/chat/src/test/java/greencity/mapping/ChatMessageWithFileDtoMapperTest.java
@@ -63,14 +63,15 @@ class ChatMessageWithFileDtoMapperTest {
 
     @Test
     void convertWithNullFields() {
-        chatMessage.setFileName(null);
-        chatMessage.setFileType(null);
-        chatMessage.setFileUrl(null);
+        ChatMessage message = new ChatMessage(1L, new ChatRoom(1L, "name", null, null,
+            ChatType.GROUP, null, null),
+            new Participant(1L, "name", "asd@asd.asd", null,
+                null, UserStatus.ACTIVATED, Role.ROLE_USER, null),
+            "content", null, null, null, null,
+            null, null);
+        ChatMessageWithFileDto expectedDto = new ChatMessageWithFileDto(1L, 1L, 1L, "content",
+            null, null, null, null, null);
 
-        expected.setFileName(null);
-        expected.setFileType(null);
-        expected.setFileUrl(null);
-
-        assertEquals(expected, chatMessageWithFileDtoMapper.convert(chatMessage));
+        assertEquals(expectedDto, chatMessageWithFileDtoMapper.convert(message));
     }
 }

--- a/chat/src/test/java/greencity/mapping/ChatMessageWithFileDtoMapperTest.java
+++ b/chat/src/test/java/greencity/mapping/ChatMessageWithFileDtoMapperTest.java
@@ -43,7 +43,7 @@ class ChatMessageWithFileDtoMapperTest {
     void convertWithLikes() {
         Set<Participant> likes = new HashSet<>();
         likes.add(new Participant(2L, "user2", "user2@example.com", null,
-                null, UserStatus.ACTIVATED, Role.ROLE_USER, null));
+            null, UserStatus.ACTIVATED, Role.ROLE_USER, null));
         chatMessage.setLikes(likes);
 
         Set<UserDto> expectedLikes = new HashSet<>();

--- a/chat/src/test/java/greencity/mapping/ChatMessageWithFileDtoMapperTest.java
+++ b/chat/src/test/java/greencity/mapping/ChatMessageWithFileDtoMapperTest.java
@@ -24,9 +24,9 @@ class ChatMessageWithFileDtoMapperTest {
             new Participant(1L, "name", "asd@asd.asd", null,
                 null, UserStatus.ACTIVATED, Role.ROLE_USER, null),
             "content", null, null, "fileName", "AUDIO",
-            "https://example.wav");
+            "https://example.wav", null);
         expected = new ChatMessageWithFileDto(1L, 1L, 1L, "content",
-            null, "fileName", "AUDIO", "https://example.wav");
+            null, "fileName", "AUDIO", "https://example.wav", null);
     }
 
     @Test

--- a/chat/src/test/java/greencity/mapping/ChatMessageWithFileDtoMapperTest.java
+++ b/chat/src/test/java/greencity/mapping/ChatMessageWithFileDtoMapperTest.java
@@ -1,6 +1,7 @@
 package greencity.mapping;
 
 import greencity.dto.ChatMessageWithFileDto;
+import greencity.dto.UserDto;
 import greencity.entity.ChatMessage;
 import greencity.entity.ChatRoom;
 import greencity.entity.Participant;
@@ -9,6 +10,10 @@ import greencity.enums.Role;
 import greencity.enums.UserStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -31,6 +36,41 @@ class ChatMessageWithFileDtoMapperTest {
 
     @Test
     void convert() {
+        assertEquals(expected, chatMessageWithFileDtoMapper.convert(chatMessage));
+    }
+
+    @Test
+    void convertWithLikes() {
+        Set<Participant> likes = new HashSet<>();
+        likes.add(new Participant(2L, "user2", "user2@example.com", null,
+                null, UserStatus.ACTIVATED, Role.ROLE_USER, null));
+        chatMessage.setLikes(likes);
+
+        Set<UserDto> expectedLikes = new HashSet<>();
+        expectedLikes.add(new UserDto(2L, "user2", null));
+        expected.setLikes(expectedLikes);
+
+        assertEquals(expected, chatMessageWithFileDtoMapper.convert(chatMessage));
+    }
+
+    @Test
+    void convertWithEmptyLikes() {
+        chatMessage.setLikes(Collections.emptySet());
+        expected.setLikes(Collections.emptySet());
+
+        assertEquals(expected, chatMessageWithFileDtoMapper.convert(chatMessage));
+    }
+
+    @Test
+    void convertWithNullFields() {
+        chatMessage.setFileName(null);
+        chatMessage.setFileType(null);
+        chatMessage.setFileUrl(null);
+
+        expected.setFileName(null);
+        expected.setFileType(null);
+        expected.setFileUrl(null);
+
         assertEquals(expected, chatMessageWithFileDtoMapper.convert(chatMessage));
     }
 }

--- a/chat/src/test/java/greencity/mapping/ChatMessageWithFileMapperTest.java
+++ b/chat/src/test/java/greencity/mapping/ChatMessageWithFileMapperTest.java
@@ -21,9 +21,9 @@ class ChatMessageWithFileMapperTest {
         expected = new ChatMessage(1L, ChatRoom.builder().id(1L).build(),
             Participant.builder().id(1L).build(),
             "content", ZonedDateTime.now(), null, "fileName", "AUDIO",
-            "https://example.wav");
+            "https://example.wav", null);
         chatMessageWithFileDto = new ChatMessageWithFileDto(1L, 1L, 1L, "content",
-            null, "fileName", "AUDIO", "https://example.wav");
+            null, "fileName", "AUDIO", "https://example.wav", null);
     }
 
     @Test

--- a/chat/src/test/java/greencity/service/impl/ChatMessageServiceImplTest.java
+++ b/chat/src/test/java/greencity/service/impl/ChatMessageServiceImplTest.java
@@ -209,6 +209,7 @@ class ChatMessageServiceImplTest {
         chatMessageServiceImpl.likeMessage(messageLike);
         verify(chatMessageRepo).addLikeToMessage(1L, 1L);
     }
+
     @Test
     void likeMessageNotFound() {
         MessageLike messageLike = new MessageLike(1L, 1L);
@@ -220,6 +221,7 @@ class ChatMessageServiceImplTest {
         assertThrows(NotFoundException.class, () -> chatMessageServiceImpl.likeMessage(messageLike));
         verify(chatMessageRepo, never()).deleteLikeFromMessage(anyLong(), anyLong());
     }
+
     @Test
     void sendVoiceMessageTest() {
         ChatMessageDto inputDto = chatMessageDto;

--- a/chat/src/test/java/greencity/service/impl/ChatMessageServiceImplTest.java
+++ b/chat/src/test/java/greencity/service/impl/ChatMessageServiceImplTest.java
@@ -183,8 +183,8 @@ class ChatMessageServiceImplTest {
             .build();
         when(chatMessageRepo.findById(1L))
             .thenReturn(Optional.of(chatMessage));
-        when(modelMapper.map(chatMessage, ChatMessageDto.class))
-            .thenReturn(expectedChatMessageDto);
+        when(modelMapper.map(chatMessage, ChatMessageWithFileDto.class))
+            .thenReturn(new ChatMessageWithFileDto());
         chatMessageServiceImpl.likeMessage(messageLike);
         verify(chatMessageRepo).deleteLikeFromMessage(1L, 1L);
     }
@@ -204,8 +204,8 @@ class ChatMessageServiceImplTest {
             .build();
         when(chatMessageRepo.findById(1L))
             .thenReturn(Optional.of(chatMessage));
-        when(modelMapper.map(chatMessage, ChatMessageDto.class))
-            .thenReturn(expectedChatMessageDto);
+        when(modelMapper.map(chatMessage, ChatMessageWithFileDto.class))
+            .thenReturn(new ChatMessageWithFileDto());
         chatMessageServiceImpl.likeMessage(messageLike);
         verify(chatMessageRepo).addLikeToMessage(1L, 1L);
     }

--- a/chat/src/test/java/greencity/service/impl/ChatMessageServiceImplTest.java
+++ b/chat/src/test/java/greencity/service/impl/ChatMessageServiceImplTest.java
@@ -209,7 +209,17 @@ class ChatMessageServiceImplTest {
         chatMessageServiceImpl.likeMessage(messageLike);
         verify(chatMessageRepo).addLikeToMessage(1L, 1L);
     }
+    @Test
+    void likeMessageNotFound() {
+        MessageLike messageLike = new MessageLike(1L, 1L);
 
+        when(chatMessageRepo.getParticipantIdIfLiked(1L, 1L)).thenReturn(null);
+        doNothing().when(chatMessageRepo).addLikeToMessage(1L, 1L);
+        when(chatMessageRepo.findById(1L)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> chatMessageServiceImpl.likeMessage(messageLike));
+        verify(chatMessageRepo, never()).deleteLikeFromMessage(anyLong(), anyLong());
+    }
     @Test
     void sendVoiceMessageTest() {
         ChatMessageDto inputDto = chatMessageDto;


### PR DESCRIPTION
## Summary Of Changes :fire:
- Added several fixes to the logic of adding/removing likes in a chat message
- Added Set(UserDto) likes field to ChatMessageWithFileDto to display users who liked the message
- Created UserDto to concisely display user information
- Fixed LazyInitializationException when loading Set(Participant) likes field in ChatMessage entity from database

## Issue Link
[#2396](https://github.com/ita-social-projects/GreenCity/issues/2396)