### PR TITLE
Fixed send messages with attachments feature

### DIFF
--- a/chat/src/main/java/greencity/config/SecurityConfig.java
+++ b/chat/src/main/java/greencity/config/SecurityConfig.java
@@ -108,7 +108,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .hasAnyRole(USER, ADMIN, MODERATOR, UBS_EMPLOYEE)
             .antMatchers(HttpMethod.POST,
                 "/chat/create-chatRoom",
-                "/chat/sent-message/{userId}/{roomId}")
+                "/chat/sent-message/{userId}/{roomId}",
+                "/chat/upload/file",
+                "/chat/upload/image",
+                "/chat/upload/voice")
             .hasAnyRole(USER, ADMIN, MODERATOR, UBS_EMPLOYEE);
     }
 

--- a/chat/src/main/java/greencity/constant/ErrorMessage.java
+++ b/chat/src/main/java/greencity/constant/ErrorMessage.java
@@ -8,6 +8,8 @@ public final class ErrorMessage {
     public static final String USER_NOT_BELONG_TO_CHAT = "This user doesnt belong to this chat";
     public static final String USER_NOT_THE_OWNER = "This user is not the owner of the chat";
     public static final String USER_IS_NOT_ADMIN = "This user is not the admin";
+    public static final String CHAT_MESSAGE_NOT_FOUND_BY_ID = "Chat message not found by id: ";
+    public static final String CHAT_MESSAGE_CANNOT_BE_EMPTY = "Message content cannot be empty!";
 
     private ErrorMessage() {
     }

--- a/chat/src/main/java/greencity/controller/ChatController.java
+++ b/chat/src/main/java/greencity/controller/ChatController.java
@@ -4,6 +4,7 @@ import greencity.annotations.ApiPageable;
 import greencity.constant.HttpStatuses;
 import greencity.dto.*;
 import greencity.enums.ChatType;
+import greencity.enums.FilesType;
 import greencity.service.*;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -87,7 +88,7 @@ public class ChatController {
     })
     @ApiPageable
     @GetMapping("/messages/{room_id}")
-    public ResponseEntity<PageableDto<ChatMessageDto>> findAllMessages(
+    public ResponseEntity<PageableDto<ChatMessageWithFileDto>> findAllMessages(
         @ApiIgnore Pageable pageable,
         @PathVariable("room_id") Long id) {
         return ResponseEntity.status(HttpStatus.OK)
@@ -262,35 +263,56 @@ public class ChatController {
     /**
      * Method for uploading an image.
      *
-     * @param file image to save.
-     * @return url of the saved image.
+     * @param file - image to save.
      */
     @ApiOperation(value = "Upload an image.")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = HttpStatuses.CREATED, response = String.class),
+        @ApiResponse(code = 201, message = HttpStatuses.CREATED, response = ChatMessageWithFileDto.class),
         @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
     })
-    @PostMapping("/upload/file")
-    public ResponseEntity<ChatMessageDto> uploadFile(@RequestBody MultipartFile file) {
-        ChatMessageDto chatMessageDto = azureFileService.saveFile(file);
-        return ResponseEntity.status(HttpStatus.OK).body(chatMessageDto);
+    @PostMapping(value = "/upload/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ChatMessageWithFileDto> uploadImage(
+        @RequestPart("chatMessageDto") @Valid ChatMessageDto chatMessageDto,
+        @RequestPart("file") MultipartFile file) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(chatMessageService.sendFile(chatMessageDto, file,
+            FilesType.IMAGE));
     }
 
     /**
-     * Method for uploading an voice file.
+     * Method for uploading file.
      *
-     * @param file voice file to save.
-     * @return url of the saved image.
+     * @param file file to save.
      */
-    @ApiOperation(value = "Upload an voice file.")
+    @ApiOperation(value = "Upload file.")
     @ApiResponses(value = {
-        @ApiResponse(code = 200, message = HttpStatuses.OK, response = ChatMessageDto.class),
+        @ApiResponse(code = 201, message = HttpStatuses.CREATED, response = ChatMessageWithFileDto.class),
         @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
     })
-    @PostMapping("/upload/voice")
-    public ResponseEntity<ChatMessageDto> uploadVoice(@RequestBody MultipartFile file) {
-        ChatMessageDto chatMessageDto = this.azureFileService.saveVoiceMessage(file);
-        return ResponseEntity.status(HttpStatus.OK).body(chatMessageDto);
+    @PostMapping(value = "/upload/file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ChatMessageWithFileDto> uploadFile(
+        @RequestPart("chatMessageDto") @Valid ChatMessageDto chatMessageDto,
+        @RequestPart("file") MultipartFile file) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(chatMessageService.sendFile(chatMessageDto, file,
+            FilesType.FILE));
+    }
+
+    /**
+     * Method for uploading voice file.
+     *
+     * @param file voice file to save.
+     * @return ChatMessageDto of the saved voice file.
+     */
+    @ApiOperation(value = "Upload voice file.")
+    @ApiResponses(value = {
+        @ApiResponse(code = 201, message = HttpStatuses.CREATED, response = ChatMessageWithFileDto.class),
+        @ApiResponse(code = 400, message = HttpStatuses.BAD_REQUEST),
+    })
+    @PostMapping(value = "/upload/voice", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ChatMessageWithFileDto> uploadVoice(
+        @RequestPart("chatMessageDto") @Valid ChatMessageDto chatMessageDto,
+        @RequestPart("file") MultipartFile file) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(chatMessageService.sendVoiceMessage(chatMessageDto, file));
     }
 
     /**

--- a/chat/src/main/java/greencity/dto/ChatFileDto.java
+++ b/chat/src/main/java/greencity/dto/ChatFileDto.java
@@ -1,0 +1,17 @@
+package greencity.dto;
+
+import greencity.enums.FilesType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatFileDto {
+    private String fileName;
+    private FilesType fileType;
+    private String fileUrl;
+}

--- a/chat/src/main/java/greencity/dto/ChatMessageWithFileDto.java
+++ b/chat/src/main/java/greencity/dto/ChatMessageWithFileDto.java
@@ -1,0 +1,25 @@
+package greencity.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
+import java.util.Set;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatMessageWithFileDto {
+    private Long id;
+    private Long roomId;
+    private Long senderId;
+    private String content;
+    private ZonedDateTime createDate;
+    private String fileName;
+    private String fileType;
+    private String fileUrl;
+    private Set<UserDto> likes;
+}

--- a/chat/src/main/java/greencity/dto/UserDto.java
+++ b/chat/src/main/java/greencity/dto/UserDto.java
@@ -1,0 +1,16 @@
+package greencity.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserDto {
+    private Long id;
+    private String name;
+    private String profilePicture;
+}

--- a/chat/src/main/java/greencity/entity/ChatMessage.java
+++ b/chat/src/main/java/greencity/entity/ChatMessage.java
@@ -1,10 +1,11 @@
 package greencity.entity;
 
 import java.time.ZonedDateTime;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import javax.persistence.*;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.*;
 
 @Entity
@@ -12,9 +13,6 @@ import lombok.*;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Setter
-@Getter
-@ToString
 @Table(name = "chat_messages")
 public class ChatMessage {
     @Id
@@ -33,4 +31,20 @@ public class ChatMessage {
 
     @OneToMany(mappedBy = "message", cascade = CascadeType.ALL)
     private List<UnreadMessage> unreadMessages;
+
+    @Column(name = "file_name")
+    private String fileName;
+
+    @Column(name = "file_type")
+    private String fileType;
+
+    @Column(name = "file_url")
+    private String fileUrl;
+
+    @ManyToMany(cascade = CascadeType.ALL)
+    @JoinTable(
+        name = "message_like",
+        joinColumns = @JoinColumn(name = "message_id"),
+        inverseJoinColumns = @JoinColumn(name = "participant_id"))
+    private Set<Participant> likes = new HashSet<>();
 }

--- a/chat/src/main/java/greencity/enums/FilesType.java
+++ b/chat/src/main/java/greencity/enums/FilesType.java
@@ -1,0 +1,5 @@
+package greencity.enums;
+
+public enum FilesType {
+    IMAGE, FILE, AUDIO
+}

--- a/chat/src/main/java/greencity/exception/exceptions/ChangesNotSavedException.java
+++ b/chat/src/main/java/greencity/exception/exceptions/ChangesNotSavedException.java
@@ -1,0 +1,12 @@
+package greencity.exception.exceptions;
+
+public class ChangesNotSavedException extends RuntimeException {
+    /**
+     * Constructor for {@link ChangesNotSavedException}.
+     *
+     * @param message - giving message.
+     */
+    public ChangesNotSavedException(String message) {
+        super(message);
+    }
+}

--- a/chat/src/main/java/greencity/mapping/ChatMessageWithFileDtoMapper.java
+++ b/chat/src/main/java/greencity/mapping/ChatMessageWithFileDtoMapper.java
@@ -1,0 +1,47 @@
+package greencity.mapping;
+
+import greencity.dto.ChatMessageWithFileDto;
+import greencity.dto.UserDto;
+import greencity.entity.ChatMessage;
+import greencity.entity.Participant;
+import org.modelmapper.AbstractConverter;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Collectors;
+
+/**
+ * Class that used by {@link ModelMapper} to map {@link ChatMessage} into
+ * {@link ChatMessageWithFileDto}.
+ */
+@Component
+public class ChatMessageWithFileDtoMapper extends AbstractConverter<ChatMessage, ChatMessageWithFileDto> {
+    /**
+     * Method convert {@link ChatMessage} to {@link ChatMessageWithFileDto}.
+     */
+    @Override
+    protected ChatMessageWithFileDto convert(ChatMessage chatMessage) {
+        return ChatMessageWithFileDto.builder()
+            .id(chatMessage.getId())
+            .content(chatMessage.getContent())
+            .createDate(chatMessage.getCreateDate())
+            .senderId(chatMessage.getSender().getId())
+            .roomId(chatMessage.getRoom().getId())
+            .fileName(chatMessage.getFileName())
+            .fileType(chatMessage.getFileType())
+            .fileUrl(chatMessage.getFileUrl())
+            .likes(chatMessage.getLikes() == null ? null
+                : chatMessage.getLikes().stream()
+                    .map(this::convertParticipant)
+                    .collect(Collectors.toSet()))
+            .build();
+    }
+
+    private UserDto convertParticipant(Participant participant) {
+        return UserDto.builder()
+            .id(participant.getId())
+            .name(participant.getName())
+            .profilePicture(participant.getProfilePicture())
+            .build();
+    }
+}

--- a/chat/src/main/java/greencity/mapping/ChatMessageWithFileMapper.java
+++ b/chat/src/main/java/greencity/mapping/ChatMessageWithFileMapper.java
@@ -1,0 +1,40 @@
+package greencity.mapping;
+
+import greencity.dto.ChatMessageWithFileDto;
+import greencity.entity.ChatMessage;
+import greencity.entity.ChatRoom;
+import greencity.entity.Participant;
+import org.modelmapper.AbstractConverter;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Component;
+
+import java.time.ZonedDateTime;
+
+/**
+ * Class that used by {@link ModelMapper} to map {@link ChatMessageWithFileDto}
+ * into {@link ChatMessage}.
+ */
+@Component
+public class ChatMessageWithFileMapper extends AbstractConverter<ChatMessageWithFileDto, ChatMessage> {
+    /**
+     * Method convert {@link ChatMessageWithFileDto} to {@link ChatMessage}.
+     *
+     * @return {@link ChatMessage}
+     */
+    @Override
+    protected ChatMessage convert(ChatMessageWithFileDto dto) {
+        return ChatMessage.builder()
+            .id(dto.getId())
+            .content(dto.getContent())
+            .sender(
+                Participant.builder()
+                    .id(dto.getSenderId()).build())
+            .createDate(ZonedDateTime.now())
+            .room(ChatRoom.builder()
+                .id(dto.getRoomId()).build())
+            .fileName(dto.getFileName())
+            .fileType(dto.getFileType())
+            .fileUrl(dto.getFileUrl())
+            .build();
+    }
+}

--- a/chat/src/main/java/greencity/repository/ChatMessageRepo.java
+++ b/chat/src/main/java/greencity/repository/ChatMessageRepo.java
@@ -3,9 +3,11 @@ package greencity.repository;
 import greencity.entity.ChatMessage;
 import greencity.entity.ChatRoom;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -23,6 +25,7 @@ public interface ChatMessageRepo extends PagingAndSortingRepository<ChatMessage,
      * @param chatRoom {@link ChatRoom} instance.
      * @return list of {@link ChatMessage} instances.
      */
+    @EntityGraph(attributePaths = {"likes", "room", "sender"})
     List<ChatMessage> findAllByRoom(ChatRoom chatRoom);
 
     /**
@@ -31,11 +34,13 @@ public interface ChatMessageRepo extends PagingAndSortingRepository<ChatMessage,
      * @param chatRoom {@link ChatRoom} instance.
      * @return list of {@link ChatMessage} instances.
      */
+    @EntityGraph(attributePaths = {"likes", "room", "sender"})
     Page<ChatMessage> findAllByRoom(@Param(value = "chatRoom") ChatRoom chatRoom, Pageable pageable);
 
     /**
      * {@inheritDoc}
      */
+    @EntityGraph(attributePaths = {"likes", "room", "sender"})
     ChatMessage findTopByOrderByIdDesc();
 
     /**
@@ -68,6 +73,7 @@ public interface ChatMessageRepo extends PagingAndSortingRepository<ChatMessage,
      * @param roomId {@link Long} id of chat room.
      * @return {@link ChatMessage} instance.
      */
+    @EntityGraph(attributePaths = {"likes", "room", "sender"})
     @Query(nativeQuery = true, value = "SELECT *  from chat_messages "
         + "where room_id = :roomId "
         + "ORDER BY chat_messages.create_date DESC limit 1")
@@ -102,5 +108,21 @@ public interface ChatMessageRepo extends PagingAndSortingRepository<ChatMessage,
      * @param roomId of chat room
      * @return list of {@link ChatMessage}s from room
      */
+    @EntityGraph(attributePaths = {"likes", "room", "sender"})
     List<ChatMessage> getAllByRoomId(Long roomId);
+
+    @Override
+    @EntityGraph(attributePaths = {"likes", "room", "sender"})
+    Optional<ChatMessage> findById(Long id);
+
+    /**
+     * Method to delete like from message by message id.
+     *
+     * @param messageId {@link Long} id of message.
+     */
+    @Modifying
+    @Transactional
+    @Query(nativeQuery = true,
+        value = "delete from message_like where message_id = :messageId")
+    void deleteLikeFromMessageByMessageId(@Param("messageId") Long messageId);
 }

--- a/chat/src/main/java/greencity/repository/UnreadMessageRepo.java
+++ b/chat/src/main/java/greencity/repository/UnreadMessageRepo.java
@@ -21,4 +21,12 @@ public interface UnreadMessageRepo extends JpaRepository<UnreadMessage, Long>,
     @Query(nativeQuery = true,
         value = "delete from unread_messages where user_id = :userId and message_id in(:messageIds)")
     void cleanUnreadMessage(Long userId, List<Long> messageIds);
+
+    /**
+     * Method to delete unread message by message id.
+     *
+     * @param messageId {@link Long} id of message.
+     */
+    @Transactional
+    void deleteByMessageId(Long messageId);
 }

--- a/chat/src/main/java/greencity/service/AzureFileService.java
+++ b/chat/src/main/java/greencity/service/AzureFileService.java
@@ -1,22 +1,23 @@
 package greencity.service;
 
-import greencity.dto.ChatMessageDto;
+import greencity.dto.ChatFileDto;
+import greencity.enums.FilesType;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface AzureFileService {
     /**
      * Method save file in azure storage.
-     * 
-     * @param multipartFile of{@link MultipartFile} return file url
+     *
+     * @param multipartFile of{@link MultipartFile} return file ChatFileDto
      */
-    ChatMessageDto saveFile(MultipartFile multipartFile);
+    ChatFileDto saveFile(MultipartFile multipartFile, FilesType fileType);
 
     /**
      * Method save voice message file in azure storage.
-     * 
-     * @param multipartFile of{@link MultipartFile} return file url
+     *
+     * @param multipartFile of{@link MultipartFile} return file ChatFileDto
      */
-    ChatMessageDto saveVoiceMessage(MultipartFile multipartFile);
+    ChatFileDto saveVoiceMessage(MultipartFile multipartFile);
 
     /**
      * Method delete file from azure storage.

--- a/chat/src/main/java/greencity/service/ChatMessageService.java
+++ b/chat/src/main/java/greencity/service/ChatMessageService.java
@@ -4,9 +4,12 @@ import greencity.dto.ChatMessageDto;
 import greencity.dto.FriendsChatDto;
 import greencity.dto.MessageLike;
 import greencity.dto.PageableDto;
+import greencity.dto.ChatMessageWithFileDto;
 import greencity.entity.ChatMessage;
 import greencity.entity.ChatRoom;
+import greencity.enums.FilesType;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface ChatMessageService {
     /**
@@ -15,7 +18,7 @@ public interface ChatMessageService {
      * @param chatRoomId {@link ChatMessage} id.
      * @return list of {@link ChatMessage} instances.
      */
-    PageableDto<ChatMessageDto> findAllMessagesByChatRoomId(Long chatRoomId, Pageable pageable);
+    PageableDto<ChatMessageWithFileDto> findAllMessagesByChatRoomId(Long chatRoomId, Pageable pageable);
 
     /**
      * Method to process all {@link ChatMessageDto}'s that are sent from client
@@ -63,4 +66,20 @@ public interface ChatMessageService {
      * @return {@link Boolean}.
      */
     FriendsChatDto chatExist(Long fistUserId, Long secondUserId);
+
+    /**
+     * Method for uploading voice file.
+     *
+     * @param voiceFile file to save.
+     * @return ChatMessageDto of the saved voice file.
+     */
+    ChatMessageWithFileDto sendVoiceMessage(ChatMessageDto chatMessageDto, MultipartFile voiceFile);
+
+    /**
+     * Method for uploading file.
+     *
+     * @param file file to save.
+     * @return ChatMessageDto of the saved voice file.
+     */
+    ChatMessageWithFileDto sendFile(ChatMessageDto chatMessageDto, MultipartFile file, FilesType fileType);
 }

--- a/chat/src/main/java/greencity/service/impl/AzureFileServiceImpl.java
+++ b/chat/src/main/java/greencity/service/impl/AzureFileServiceImpl.java
@@ -4,8 +4,10 @@ import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.BlobHttpHeaders;
 import greencity.constant.ErrorMessage;
-import greencity.dto.ChatMessageDto;
+import greencity.dto.ChatFileDto;
+import greencity.enums.FilesType;
 import greencity.exception.exceptions.FileNotSavedException;
 import greencity.service.AzureFileService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +16,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.io.ByteArrayOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.UUID;
 
 @Service
@@ -31,30 +36,17 @@ public class AzureFileServiceImpl implements AzureFileService {
     }
 
     @Override
-    public ChatMessageDto saveFile(MultipartFile multipartFile) {
-        final String blob = UUID.randomUUID().toString();
-        String blobName = blob + multipartFile.getOriginalFilename();
-        BlobClient blobClient = containerClient().getBlobClient(blobName);
-        try {
-            blobClient.upload(multipartFile.getInputStream(), multipartFile.getSize());
-        } catch (IOException e) {
-            throw new FileNotSavedException(ErrorMessage.FILE_NOT_SAVED);
-        }
-
-        return new ChatMessageDto();
+    public ChatFileDto saveFile(MultipartFile multipartFile, FilesType fileType) {
+        ChatFileDto chatFileDto = uploadFile(multipartFile, multipartFile.getOriginalFilename());
+        chatFileDto.setFileType(fileType);
+        return chatFileDto;
     }
 
     @Override
-    public ChatMessageDto saveVoiceMessage(MultipartFile multipartFile) {
-        final String blob = UUID.randomUUID().toString();
-        String blobName = blob + WAV;
-        BlobClient blobClient = containerClient().getBlobClient(blobName);
-        try {
-            blobClient.upload(multipartFile.getInputStream(), multipartFile.getSize());
-        } catch (IOException e) {
-            throw new FileNotSavedException(ErrorMessage.FILE_NOT_SAVED);
-        }
-        return new ChatMessageDto();
+    public ChatFileDto saveVoiceMessage(MultipartFile multipartFile) {
+        ChatFileDto chatFileDto = uploadFile(multipartFile, WAV);
+        chatFileDto.setFileType(FilesType.AUDIO);
+        return chatFileDto;
     }
 
     @Override
@@ -67,5 +59,36 @@ public class AzureFileServiceImpl implements AzureFileService {
         BlobServiceClient serviceClient = new BlobServiceClientBuilder()
             .connectionString(connectionString).buildClient();
         return serviceClient.getBlobContainerClient(containerName);
+    }
+
+    private ChatFileDto uploadFile(MultipartFile file, String fileName) {
+        final String blob = UUID.randomUUID().toString();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try {
+            file.getInputStream().transferTo(baos);
+        } catch (IOException e) {
+            throw new FileNotSavedException(ErrorMessage.FILE_NOT_SAVED);
+        }
+
+        byte[] fileBytes = baos.toByteArray();
+
+        BlobContainerClient containerClient = containerClient();
+        String blobName = blob + fileName;
+        BlobClient blobClient = containerClient.getBlobClient(blobName);
+
+        try (InputStream inputStream = new ByteArrayInputStream(fileBytes)) {
+            blobClient.upload(inputStream, fileBytes.length, true);
+        } catch (IOException e) {
+            throw new FileNotSavedException(ErrorMessage.FILE_NOT_SAVED);
+        }
+
+        BlobHttpHeaders headers = new BlobHttpHeaders()
+            .setContentType(file.getContentType());
+        blobClient.setHttpHeaders(headers);
+
+        return ChatFileDto.builder()
+            .fileName(blobClient.getBlobName())
+            .fileUrl(blobClient.getBlobUrl())
+            .build();
     }
 }

--- a/chat/src/main/java/greencity/service/impl/ChatMessageServiceImpl.java
+++ b/chat/src/main/java/greencity/service/impl/ChatMessageServiceImpl.java
@@ -6,11 +6,14 @@ import greencity.entity.ChatMessage;
 import greencity.entity.ChatRoom;
 import greencity.entity.Participant;
 import greencity.entity.UnreadMessage;
+import greencity.enums.FilesType;
 import greencity.enums.MessageStatus;
 import greencity.enums.SortOrder;
 import greencity.exception.exceptions.ChatRoomNotFoundException;
 import greencity.exception.exceptions.UserNotBelongToThisChat;
 import greencity.exception.exceptions.UserNotFoundException;
+import greencity.exception.exceptions.ChangesNotSavedException;
+import greencity.exception.exceptions.FileNotFoundException;
 import greencity.repository.ChatMessageRepo;
 import greencity.repository.ChatRoomRepo;
 import greencity.repository.ParticipantRepo;
@@ -32,6 +35,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 /**
  * Implementation of {@link ChatMessageService}.
@@ -53,7 +57,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
     private static final String HEADER_UPDATE = "update";
 
     @Override
-    public PageableDto<ChatMessageDto> findAllMessagesByChatRoomId(Long chatRoomId, Pageable pageable) {
+    public PageableDto<ChatMessageWithFileDto> findAllMessagesByChatRoomId(Long chatRoomId, Pageable pageable) {
         ChatRoom chatRoom = chatRoomRepo.findById(chatRoomId)
             .orElseThrow(() -> new ChatRoomNotFoundException(ErrorMessage.CHAT_ROOM_NOT_FOUND_BY_ID));
 
@@ -61,8 +65,8 @@ public class ChatMessageServiceImpl implements ChatMessageService {
         pageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
 
         Page<ChatMessage> messages = chatMessageRepo.findAllByRoom(chatRoom, pageable);
-        List<ChatMessageDto> messageDtos = messages.getContent().stream()
-            .map(message -> modelMapper.map(message, ChatMessageDto.class)).collect(Collectors.toList());
+        List<ChatMessageWithFileDto> messageDtos = messages.getContent().stream()
+            .map(message -> modelMapper.map(message, ChatMessageWithFileDto.class)).collect(Collectors.toList());
 
         Collections.reverse(messageDtos);
         return new PageableDto<>(
@@ -97,23 +101,30 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 
     @Override
     public void deleteMessage(ChatMessageDto chatMessageDto) {
-        ChatMessage chatMessage = modelMapper.map(chatMessageDto, ChatMessage.class);
-        chatMessageRepo.delete(chatMessage);
-        Map<String, Object> headers = new HashMap<>();
-
-        headers.put(HEADER_DELETE, new Object());
-        messagingTemplate.convertAndSend(
-            ROOM_LINK + chatMessageDto.getRoomId() + MESSAGE_LINK, chatMessageDto, headers);
+        Long chatMessageId = chatMessageDto.getId();
+        ChatMessage chatMessage = chatMessageRepo.findById(chatMessageId)
+            .orElseThrow(() -> new FileNotFoundException(ErrorMessage.CHAT_MESSAGE_NOT_FOUND_BY_ID
+                + chatMessageId));
+        if (chatMessage.getFileName() != null) {
+            azureFileService.deleteFile(chatMessage.getFileName());
+        }
+        unreadMessageRepo.deleteByMessageId(chatMessageId);
+        chatMessageRepo.deleteLikeFromMessageByMessageId(chatMessageId);
+        chatMessageRepo.deleteById(chatMessageId);
+        sendMessageInChatRoomWithHeader(modelMapper.map(chatMessage, ChatMessageWithFileDto.class), HEADER_DELETE);
     }
 
     @Override
     public void updateMessage(ChatMessageDto chatMessageDto) {
-        ChatMessage chatMessage = modelMapper.map(chatMessageDto, ChatMessage.class);
+        ChatMessage chatMessage = chatMessageRepo.findById(chatMessageDto.getId())
+            .orElseThrow(() -> new FileNotFoundException(ErrorMessage.CHAT_MESSAGE_NOT_FOUND_BY_ID
+                + chatMessageDto.getId()));
+        if (chatMessageDto.getContent().isEmpty()) {
+            throw new ChangesNotSavedException(ErrorMessage.CHAT_MESSAGE_CANNOT_BE_EMPTY);
+        }
+        chatMessage.setContent(chatMessageDto.getContent());
         chatMessageRepo.save(chatMessage);
-        Map<String, Object> headers = new HashMap<>();
-        headers.put(HEADER_UPDATE, new Object());
-        messagingTemplate.convertAndSend(
-            ROOM_LINK + chatMessageDto.getRoomId() + MESSAGE_LINK, chatMessageDto, headers);
+        sendMessageInChatRoomWithHeader(modelMapper.map(chatMessage, ChatMessageWithFileDto.class), HEADER_UPDATE);
     }
 
     @Override
@@ -128,13 +139,10 @@ public class ChatMessageServiceImpl implements ChatMessageService {
         } else {
             chatMessageRepo.addLikeToMessage(messageLike.getMessageId(), messageLike.getParticipantId());
         }
-        Map<String, Object> headers = new HashMap<>();
-        headers.put(HEADER_UPDATE, new Object());
-        ChatMessage chatMessage = chatMessageRepo.findById(messageLike.getMessageId()).get();
-        ChatMessageDto chatMessageDto = modelMapper.map(chatMessage,
-            ChatMessageDto.class);
-        messagingTemplate.convertAndSend(
-            ROOM_LINK + chatMessage.getRoom().getId() + MESSAGE_LINK, chatMessageDto, headers);
+        ChatMessage chatMessage = chatMessageRepo.findById(messageLike.getMessageId())
+            .orElseThrow(() -> new FileNotFoundException(ErrorMessage.CHAT_MESSAGE_NOT_FOUND_BY_ID
+                + messageLike.getMessageId()));
+        sendMessageInChatRoomWithHeader(modelMapper.map(chatMessage, ChatMessageWithFileDto.class), HEADER_UPDATE);
     }
 
     @Override
@@ -197,5 +205,41 @@ public class ChatMessageServiceImpl implements ChatMessageService {
             friendsChatDto.setChatId(chatList.get(0));
         }
         return friendsChatDto;
+    }
+
+    @Override
+    public ChatMessageWithFileDto sendVoiceMessage(ChatMessageDto chatMessageDto, MultipartFile voiceFile) {
+        ChatFileDto chatFileDto = azureFileService.saveVoiceMessage(voiceFile);
+        ChatMessageWithFileDto chatMessageWithFileDto = mergeChatMessageAndFile(chatMessageDto, chatFileDto);
+        ChatMessage chatMessage = modelMapper.map(chatMessageWithFileDto, ChatMessage.class);
+        return modelMapper.map(chatMessageRepo.save(chatMessage), ChatMessageWithFileDto.class);
+    }
+
+    @Override
+    public ChatMessageWithFileDto sendFile(ChatMessageDto chatMessageDto, MultipartFile file, FilesType fileType) {
+        ChatFileDto chatFileDto = azureFileService.saveFile(file, fileType);
+        ChatMessageWithFileDto chatMessageWithFileDto = mergeChatMessageAndFile(chatMessageDto, chatFileDto);
+        ChatMessage chatMessage = modelMapper.map(chatMessageWithFileDto, ChatMessage.class);
+        return modelMapper.map(chatMessageRepo.save(chatMessage), ChatMessageWithFileDto.class);
+    }
+
+    private ChatMessageWithFileDto mergeChatMessageAndFile(ChatMessageDto chatMessageDto, ChatFileDto chatFileDto) {
+        return ChatMessageWithFileDto.builder()
+            .id(chatMessageDto.getId())
+            .roomId(chatMessageDto.getRoomId())
+            .senderId(chatMessageDto.getSenderId())
+            .content(chatMessageDto.getContent())
+            .createDate(chatMessageDto.getCreateDate())
+            .fileUrl(chatFileDto.getFileUrl())
+            .fileType(chatFileDto.getFileType().toString())
+            .fileName(chatFileDto.getFileName())
+            .build();
+    }
+
+    private void sendMessageInChatRoomWithHeader(ChatMessageWithFileDto chatMessageWithFileDto, String headerString) {
+        Map<String, Object> headers = new HashMap<>();
+        headers.put(headerString, new Object());
+        messagingTemplate.convertAndSend(
+            ROOM_LINK + chatMessageWithFileDto.getRoomId() + MESSAGE_LINK, chatMessageWithFileDto, headers);
     }
 }

--- a/chat/src/test/java/greencity/controller/ChatControllerTest.java
+++ b/chat/src/test/java/greencity/controller/ChatControllerTest.java
@@ -1,9 +1,11 @@
 package greencity.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import greencity.dto.*;
 import greencity.entity.Participant;
 import greencity.enums.ChatStatus;
 import greencity.enums.ChatType;
+import greencity.enums.FilesType;
 import greencity.service.AzureFileService;
 import greencity.service.ChatMessageService;
 import greencity.service.ChatRoomService;
@@ -22,11 +24,14 @@ import org.mockito.quality.Strictness;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.multipart.MultipartFile;
+
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
@@ -184,30 +189,83 @@ class ChatControllerTest {
     }
 
     @Test
-    void uploadFileTest() throws Exception {
-        MockMultipartFile file =
-            new MockMultipartFile("file", new byte[1]);
-        ChatMessageDto chatMessageDto = new ChatMessageDto();
-        when(azureFileService.saveFile(file)).thenReturn(chatMessageDto);
-        mockMvc.perform(multipart(chatLink + "/upload/file")
-            .file(file))
-            .andExpect(status().isOk());
+    void uploadImageTest() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("file", "testImage.png",
+            "image/png", new byte[1]);
+        ChatMessageWithFileDto chatMessageWithFileDto = ChatMessageWithFileDto.builder()
+            .senderId(1L)
+            .roomId(1L)
+            .content("content")
+            .build();
 
-        verify(azureFileService).saveFile(file);
+        ObjectMapper objectMapper = new ObjectMapper();
+        String chatMessageDtoJson = objectMapper.writeValueAsString(chatMessageWithFileDto);
+        MockMultipartFile chatMessageDtoFile = new MockMultipartFile("chatMessageDto", "",
+            "application/json", chatMessageDtoJson.getBytes());
+
+        when(chatMessageService.sendFile(any(ChatMessageDto.class), any(MultipartFile.class), any(FilesType.class)))
+            .thenReturn(chatMessageWithFileDto);
+
+        mockMvc.perform(multipart(chatLink + "/upload/image")
+            .file(file)
+            .file(chatMessageDtoFile)
+            .contentType(MediaType.MULTIPART_FORM_DATA))
+            .andExpect(status().isCreated());
+
+        verify(chatMessageService).sendFile(any(ChatMessageDto.class), any(MultipartFile.class), any(FilesType.class));
+    }
+
+    @Test
+    void uploadFileTest() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("file", "testFile.pdf",
+            "application/pdf", new byte[1]);
+        ChatMessageWithFileDto chatMessageWithFileDto = ChatMessageWithFileDto.builder()
+            .senderId(1L)
+            .roomId(1L)
+            .content("content")
+            .build();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String chatMessageDtoJson = objectMapper.writeValueAsString(chatMessageWithFileDto);
+        MockMultipartFile chatMessageDtoFile = new MockMultipartFile("chatMessageDto", "",
+            "application/json", chatMessageDtoJson.getBytes());
+
+        when(chatMessageService.sendFile(any(ChatMessageDto.class), any(MultipartFile.class), any(FilesType.class)))
+            .thenReturn(chatMessageWithFileDto);
+
+        mockMvc.perform(multipart(chatLink + "/upload/file")
+            .file(file)
+            .file(chatMessageDtoFile)
+            .contentType(MediaType.MULTIPART_FORM_DATA))
+            .andExpect(status().isCreated());
+
+        verify(chatMessageService).sendFile(any(ChatMessageDto.class), any(MultipartFile.class), any(FilesType.class));
     }
 
     @Test
     void uploadVoiceTest() throws Exception {
-        MockMultipartFile file =
-            new MockMultipartFile("file", new byte[1]);
-        ChatMessageDto chatMessageDto = new ChatMessageDto();
-        when(this.azureFileService.saveVoiceMessage(file)).thenReturn(chatMessageDto);
+        MockMultipartFile file = new MockMultipartFile("file", "testFile.mp3",
+            "audio/mp3", new byte[1]);
+        ChatMessageWithFileDto chatMessageWithFileDto = ChatMessageWithFileDto.builder()
+            .senderId(1L)
+            .roomId(1L)
+            .content("content")
+            .build();
+        ObjectMapper objectMapper = new ObjectMapper();
+        String chatMessageDtoJson = objectMapper.writeValueAsString(chatMessageWithFileDto);
+        MockMultipartFile chatMessageDtoFile = new MockMultipartFile("chatMessageDto", "",
+            "application/json", chatMessageDtoJson.getBytes());
+
+        when(chatMessageService.sendVoiceMessage(any(ChatMessageDto.class), any(MultipartFile.class)))
+            .thenReturn(chatMessageWithFileDto);
+
         mockMvc.perform(multipart(chatLink + "/upload/voice")
-            .file(file))
-            .andExpect(status().isOk());
+            .file(file)
+            .file(chatMessageDtoFile)
+            .contentType(MediaType.MULTIPART_FORM_DATA))
+            .andExpect(status().isCreated());
 
-        verify(this.azureFileService).saveVoiceMessage(file);
-
+        verify(chatMessageService).sendVoiceMessage(any(ChatMessageDto.class), any(MultipartFile.class));
     }
 
     @Test

--- a/chat/src/test/java/greencity/mapping/ChatMessageDtoMapperTest.java
+++ b/chat/src/test/java/greencity/mapping/ChatMessageDtoMapperTest.java
@@ -23,10 +23,12 @@ class ChatMessageDtoMapperTest {
     @BeforeEach
     void init() {
         chatMessage =
-            new ChatMessage(1L, new ChatRoom(1L, "name", null, null, ChatType.GROUP, ChatStatus.NEW, 1L, null, "logo"),
+            new ChatMessage(1L, new ChatRoom(1L, "name", null, null, ChatType.GROUP,
+                ChatStatus.NEW, 1L, null, "logo"),
                 new Participant(1L, "name", "asd@asd.asd", null,
                     null, UserStatus.ACTIVATED, Role.ROLE_USER, null),
-                "content", null, null);
+                "content", null, null, "fileName", "FILE",
+                "fileUrl", null);
         expected = new ChatMessageDto(1L, 1L, 1L, "content",
             null);
     }

--- a/chat/src/test/java/greencity/mapping/ChatMessageMapperTest.java
+++ b/chat/src/test/java/greencity/mapping/ChatMessageMapperTest.java
@@ -18,8 +18,8 @@ class ChatMessageMapperTest {
     @BeforeEach
     void init() {
         expected = new ChatMessage(1L, ChatRoom.builder().id(1L).build(),
-            Participant.builder().id(1L).build(),
-            "content", ZonedDateTime.now(), null);
+            Participant.builder().id(1L).build(), "content", ZonedDateTime.now(),
+            null, null, null, null, null);
         chatMessageDto = new ChatMessageDto(1L, 1L, 1L, "content",
             null);
     }

--- a/chat/src/test/java/greencity/mapping/ChatMessageWithFileDtoMapperTest.java
+++ b/chat/src/test/java/greencity/mapping/ChatMessageWithFileDtoMapperTest.java
@@ -1,0 +1,79 @@
+package greencity.mapping;
+
+import greencity.dto.ChatMessageWithFileDto;
+import greencity.dto.UserDto;
+import greencity.entity.ChatMessage;
+import greencity.entity.ChatRoom;
+import greencity.entity.Participant;
+import greencity.enums.ChatStatus;
+import greencity.enums.ChatType;
+import greencity.enums.Role;
+import greencity.enums.UserStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ChatMessageWithFileDtoMapperTest {
+    private ChatMessageWithFileDto expected;
+    private ChatMessage chatMessage;
+    private final ChatMessageWithFileDtoMapper chatMessageWithFileDtoMapper = new ChatMessageWithFileDtoMapper();
+
+    @BeforeEach
+    void init() {
+        chatMessage = new ChatMessage(1L, new ChatRoom(1L, "name", null, null,
+            ChatType.GROUP, ChatStatus.NEW, 1L, null, "logo"),
+            new Participant(1L, "name", "asd@asd.asd", null,
+                null, UserStatus.ACTIVATED, Role.ROLE_USER, null),
+            "content", null, null, "fileName", "AUDIO",
+            "https://example.wav", null);
+        expected = new ChatMessageWithFileDto(1L, 1L, 1L, "content",
+            null, "fileName", "AUDIO", "https://example.wav", null);
+    }
+
+    @Test
+    void convert() {
+        assertEquals(expected, chatMessageWithFileDtoMapper.convert(chatMessage));
+    }
+
+    @Test
+    void convertWithLikes() {
+        Set<Participant> likes = new HashSet<>();
+        likes.add(new Participant(2L, "user2", "user2@example.com", null,
+            null, UserStatus.ACTIVATED, Role.ROLE_USER, null));
+        chatMessage.setLikes(likes);
+
+        Set<UserDto> expectedLikes = new HashSet<>();
+        expectedLikes.add(new UserDto(2L, "user2", null));
+        expected.setLikes(expectedLikes);
+
+        assertEquals(expected, chatMessageWithFileDtoMapper.convert(chatMessage));
+    }
+
+    @Test
+    void convertWithEmptyLikes() {
+        chatMessage.setLikes(Collections.emptySet());
+        expected.setLikes(Collections.emptySet());
+
+        assertEquals(expected, chatMessageWithFileDtoMapper.convert(chatMessage));
+    }
+
+    @Test
+    void convertWithNullFields() {
+        ChatMessage message = new ChatMessage(1L, new ChatRoom(1L, "name", null, null,
+            ChatType.GROUP, ChatStatus.NEW, 1L, null, "logo"),
+            new Participant(1L, "name", "asd@asd.asd", null,
+                null, UserStatus.ACTIVATED, Role.ROLE_USER, null),
+            "content", null, null, null, null,
+            null, null);
+        ChatMessageWithFileDto expectedDto = new ChatMessageWithFileDto(1L, 1L, 1L, "content",
+            null, null, null, null, null);
+
+        assertEquals(expectedDto, chatMessageWithFileDtoMapper.convert(message));
+    }
+
+}

--- a/chat/src/test/java/greencity/mapping/ChatMessageWithFileMapperTest.java
+++ b/chat/src/test/java/greencity/mapping/ChatMessageWithFileMapperTest.java
@@ -1,0 +1,41 @@
+package greencity.mapping;
+
+import greencity.dto.ChatMessageWithFileDto;
+import greencity.entity.ChatMessage;
+import greencity.entity.ChatRoom;
+import greencity.entity.Participant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ChatMessageWithFileMapperTest {
+    private ChatMessage expected;
+    private ChatMessageWithFileDto chatMessageWithFileDto;
+    private ChatMessageWithFileMapper chatMessageWithFileMapper = new ChatMessageWithFileMapper();
+
+    @BeforeEach
+    void init() {
+        expected = new ChatMessage(1L, ChatRoom.builder().id(1L).build(),
+            Participant.builder().id(1L).build(),
+            "content", ZonedDateTime.now(), null, "fileName", "AUDIO",
+            "https://example.wav", null);
+        chatMessageWithFileDto = new ChatMessageWithFileDto(1L, 1L, 1L, "content",
+            null, "fileName", "AUDIO", "https://example.wav", null);
+    }
+
+    @Test
+    void convert() {
+        ChatMessage actual = chatMessageWithFileMapper.convert(chatMessageWithFileDto);
+        assertEquals(expected.getId(), actual.getId());
+        assertEquals(expected.getContent(), actual.getContent());
+        assertEquals(expected.getSender(), actual.getSender());
+        assertEquals(expected.getRoom(), actual.getRoom());
+        assertEquals(expected.getFileName(), actual.getFileName());
+        assertEquals(expected.getFileType(), actual.getFileType());
+        assertEquals(expected.getFileUrl(), actual.getFileUrl());
+    }
+
+}

--- a/chat/src/test/java/greencity/service/impl/ChatMessageServiceImplTest.java
+++ b/chat/src/test/java/greencity/service/impl/ChatMessageServiceImplTest.java
@@ -1,20 +1,23 @@
 package greencity.service.impl;
 
-import greencity.dto.ChatMessageDto;
-import greencity.dto.ChatMessageResponseDto;
-import greencity.dto.MessageLike;
-import greencity.dto.PageableDto;
+import greencity.dto.*;
 import greencity.entity.ChatMessage;
 import greencity.entity.ChatRoom;
 import greencity.entity.Participant;
+import greencity.enums.FilesType;
 import greencity.enums.SortOrder;
+import greencity.exception.exceptions.ChangesNotSavedException;
+import greencity.exception.exceptions.FileNotFoundException;
 import greencity.repository.ChatMessageRepo;
 import greencity.repository.ChatRoomRepo;
 
+import java.lang.reflect.Method;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.*;
 
+import greencity.repository.UnreadMessageRepo;
+import greencity.service.AzureFileService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,8 +27,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.*;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.multipart.MultipartFile;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
@@ -42,6 +47,10 @@ class ChatMessageServiceImplTest {
     private ModelMapper modelMapper;
     @Mock
     private ChatRoomRepo chatRoomRepo;
+    @Mock
+    private AzureFileService azureFileService;
+    @Mock
+    private UnreadMessageRepo unreadMessageRepo;
     ChatMessageDto expectedChatMessageDto;
 
     ChatMessageDto chatMessageDto;
@@ -103,13 +112,13 @@ class ChatMessageServiceImplTest {
         PageRequest pageRequest =
             PageRequest.of(0, 1, Sort.by(Sort.Direction.valueOf(SortOrder.DESC.toString()), "createDate"));
         Page<ChatMessage> messages = new PageImpl<>(Collections.singletonList(chatMessage), pageRequest, 1);
-        ChatMessageDto chatMessageDto = ChatMessageDto.builder()
+        ChatMessageWithFileDto chatMessageWithFileDto = ChatMessageWithFileDto.builder()
             .id(1L)
             .content("test")
             .roomId(1L)
             .senderId(1L)
             .build();
-        List<ChatMessageDto> chatMessageDtos = Collections.singletonList(chatMessageDto);
+        List<ChatMessageWithFileDto> chatMessageDtos = Collections.singletonList(chatMessageWithFileDto);
         PageableDto pageableDto = new PageableDto<>(
             chatMessageDtos,
             messages.getTotalElements(),
@@ -120,9 +129,11 @@ class ChatMessageServiceImplTest {
 
         when(chatMessageRepo.findAllByRoom(chatRoom, pageRequest)).thenReturn(messages);
 
-        when(modelMapper.map(messages.getContent().get(0), ChatMessageDto.class)).thenReturn(chatMessageDto);
+        when(modelMapper.map(messages.getContent().get(0), ChatMessageWithFileDto.class))
+            .thenReturn(chatMessageWithFileDto);
 
-        PageableDto<ChatMessageDto> actual = chatMessageServiceImpl.findAllMessagesByChatRoomId(1L, pageRequest);
+        PageableDto<ChatMessageWithFileDto> actual =
+            chatMessageServiceImpl.findAllMessagesByChatRoomId(1L, pageRequest);
         assertEquals(pageableDto, actual);
     }
 
@@ -145,17 +156,6 @@ class ChatMessageServiceImplTest {
     }
 
     @Test
-    void deleteMessage() {
-        when(modelMapper.map(chatMessageDto, ChatMessage.class)).thenReturn(expectedChatMessage);
-        doNothing().when(chatMessageRepo).delete(expectedChatMessage);
-        doNothing().when(messagingTemplate).convertAndSend(eq("/room/1/queue/messages"), eq(chatMessageDto),
-            anyMap());
-        chatMessageServiceImpl.deleteMessage(expectedChatMessageDto);
-
-        verify(chatMessageRepo).delete(expectedChatMessage);
-    }
-
-    @Test
     void deleteLikeFromMessage() {
         MessageLike messageLike = new MessageLike(1L, 1L);
         when(chatMessageRepo.getParticipantIdIfLiked(1L, 1L)).thenReturn(1L);
@@ -170,8 +170,8 @@ class ChatMessageServiceImplTest {
             .build();
         when(chatMessageRepo.findById(1L))
             .thenReturn(Optional.of(chatMessage));
-        when(modelMapper.map(chatMessage, ChatMessageDto.class))
-            .thenReturn(expectedChatMessageDto);
+        when(modelMapper.map(chatMessage, ChatMessageWithFileDto.class))
+            .thenReturn(new ChatMessageWithFileDto());
         chatMessageServiceImpl.likeMessage(messageLike);
         verify(chatMessageRepo).deleteLikeFromMessage(1L, 1L);
     }
@@ -191,10 +191,294 @@ class ChatMessageServiceImplTest {
             .build();
         when(chatMessageRepo.findById(1L))
             .thenReturn(Optional.of(chatMessage));
-        when(modelMapper.map(chatMessage, ChatMessageDto.class))
-            .thenReturn(expectedChatMessageDto);
+        when(modelMapper.map(chatMessage, ChatMessageWithFileDto.class))
+            .thenReturn(new ChatMessageWithFileDto());
         chatMessageServiceImpl.likeMessage(messageLike);
         verify(chatMessageRepo).addLikeToMessage(1L, 1L);
     }
 
+    @Test
+    void likeMessageNotFound() {
+        MessageLike messageLike = new MessageLike(1L, 1L);
+
+        when(chatMessageRepo.getParticipantIdIfLiked(1L, 1L)).thenReturn(null);
+        doNothing().when(chatMessageRepo).addLikeToMessage(1L, 1L);
+        when(chatMessageRepo.findById(1L)).thenReturn(Optional.empty());
+
+        assertThrows(FileNotFoundException.class, () -> chatMessageServiceImpl.likeMessage(messageLike));
+        verify(chatMessageRepo, never()).deleteLikeFromMessage(anyLong(), anyLong());
+    }
+
+    @Test
+    void sendVoiceMessageTest() {
+        ChatMessageDto inputDto = chatMessageDto;
+        ChatMessage expectedMessage = expectedChatMessage;
+        MultipartFile mockVoiceFile = mock(MultipartFile.class);
+        ChatFileDto mockedFileDto = new ChatFileDto("testFile.mp3", FilesType.AUDIO,
+            "https://example.com/testFile.mp3");
+        ChatMessageWithFileDto expectedDto = ChatMessageWithFileDto.builder()
+            .roomId(1L)
+            .senderId(1L)
+            .createDate(ZonedDateTime.of(2022, 12, 12, 12, 12, 12, 12, ZoneId.systemDefault()))
+            .content("test").senderId(1L)
+            .fileName(mockedFileDto.getFileName())
+            .fileType(mockedFileDto.getFileType().toString())
+            .fileUrl(mockedFileDto.getFileUrl())
+            .build();
+        expectedMessage.setFileUrl(mockedFileDto.getFileUrl());
+        expectedMessage.setFileName(mockedFileDto.getFileName());
+        expectedMessage.setFileType(mockedFileDto.getFileType().toString());
+
+        when(azureFileService.saveVoiceMessage(any(MultipartFile.class))).thenReturn(mockedFileDto);
+        when(modelMapper.map(expectedDto, ChatMessage.class))
+            .thenReturn(expectedMessage);
+        when(chatMessageRepo.save(any(ChatMessage.class))).thenReturn(expectedMessage);
+        when(modelMapper.map(expectedMessage, ChatMessageWithFileDto.class))
+            .thenReturn(expectedDto);
+
+        ChatMessageWithFileDto resultDto = chatMessageServiceImpl.sendVoiceMessage(inputDto, mockVoiceFile);
+
+        verify(azureFileService).saveVoiceMessage(any(MultipartFile.class));
+        verify(chatMessageRepo).save(any(ChatMessage.class));
+
+        assertEquals(resultDto, expectedDto);
+    }
+
+    @Test
+    void sendFileTest() {
+        MultipartFile mockFile = mock(MultipartFile.class);
+        ChatMessageDto inputDto = chatMessageDto;
+        ChatMessage expectedMessage = expectedChatMessage;
+        FilesType fileType = FilesType.FILE;
+        ChatFileDto mockedFileDto = new ChatFileDto("testFile.pdf", fileType,
+            "https://example.com/testFile.pdf");
+        ChatMessageWithFileDto expectedDto = ChatMessageWithFileDto.builder()
+            .roomId(1L)
+            .senderId(1L)
+            .createDate(ZonedDateTime.of(2022, 12, 12, 12, 12, 12, 12, ZoneId.systemDefault()))
+            .content("test").senderId(1L)
+            .fileName(mockedFileDto.getFileName())
+            .fileType(mockedFileDto.getFileType().toString())
+            .fileUrl(mockedFileDto.getFileUrl())
+            .build();
+        expectedMessage.setFileUrl(mockedFileDto.getFileUrl());
+        expectedMessage.setFileName(mockedFileDto.getFileName());
+        expectedMessage.setFileType(mockedFileDto.getFileType().toString());
+
+        when(azureFileService.saveFile(any(MultipartFile.class), any())).thenReturn(mockedFileDto);
+        when(modelMapper.map(expectedDto, ChatMessage.class))
+            .thenReturn(expectedMessage);
+        when(chatMessageRepo.save(any(ChatMessage.class))).thenReturn(expectedMessage);
+        when(modelMapper.map(expectedMessage, ChatMessageWithFileDto.class))
+            .thenReturn(expectedDto);
+
+        ChatMessageWithFileDto resultDto = chatMessageServiceImpl.sendFile(inputDto, mockFile, fileType);
+
+        verify(azureFileService).saveFile(any(MultipartFile.class), eq(fileType));
+        verify(chatMessageRepo).save(any(ChatMessage.class));
+
+        assertEquals(resultDto, expectedDto);
+    }
+
+    @Test
+    void mergeChatMessageAndFileTest() throws Exception {
+        ChatFileDto chatFileDto = new ChatFileDto("testFile.mp3", FilesType.AUDIO,
+            "https://example.com/testFile.mp3");
+        ChatMessageDto dto = ChatMessageDto.builder()
+            .id(1L)
+            .roomId(2L)
+            .senderId(3L)
+            .content("Test content")
+            .createDate(ZonedDateTime.now())
+            .build();
+
+        Method method = ChatMessageServiceImpl.class.getDeclaredMethod("mergeChatMessageAndFile",
+            ChatMessageDto.class, ChatFileDto.class);
+        method.setAccessible(true);
+
+        ChatMessageWithFileDto result = (ChatMessageWithFileDto) method.invoke(chatMessageServiceImpl,
+            dto, chatFileDto);
+
+        assertEquals(dto.getId(), result.getId());
+        assertEquals(dto.getRoomId(), result.getRoomId());
+        assertEquals(dto.getSenderId(), result.getSenderId());
+        assertEquals(dto.getContent(), result.getContent());
+        assertEquals(dto.getCreateDate(), result.getCreateDate());
+        assertEquals(chatFileDto.getFileName(), result.getFileName());
+        assertEquals(chatFileDto.getFileType().toString(), result.getFileType());
+        assertEquals(chatFileDto.getFileUrl(), result.getFileUrl());
+    }
+
+    @Test
+    void deleteMessageTest_successfulWithoutFile() {
+        Long id = 1L;
+        ChatMessageWithFileDto chatMessageWithFileDto = ChatMessageWithFileDto.builder()
+            .id(1L)
+            .roomId(1L)
+            .senderId(1L)
+            .content("Content")
+            .build();
+        ChatMessageDto messageDto = ChatMessageDto.builder()
+            .id(1L)
+            .roomId(1L)
+            .senderId(1L)
+            .content("Content")
+            .build();
+        ChatMessage chatMessage = ChatMessage.builder()
+            .id(1L)
+            .room(ChatRoom.builder().id(1L).name("TestName").build())
+            .sender(Participant.builder().id(1L).name("User").build())
+            .content("Content")
+            .build();
+
+        when(chatMessageRepo.findById(anyLong())).thenReturn(Optional.of(chatMessage));
+        doNothing().when(unreadMessageRepo).deleteByMessageId(id);
+        doNothing().when(chatMessageRepo).deleteLikeFromMessageByMessageId(id);
+        doNothing().when(chatMessageRepo).deleteById(id);
+        when(modelMapper.map(chatMessage, ChatMessageWithFileDto.class)).thenReturn(chatMessageWithFileDto);
+        doNothing().when(messagingTemplate).convertAndSend(anyString(), any(ChatMessageWithFileDto.class),
+            (Map<String, Object>) any());
+
+        chatMessageServiceImpl.deleteMessage(messageDto);
+
+        verify(chatMessageRepo).deleteById(id);
+        verify(azureFileService, never()).deleteFile(anyString());
+        verify(messagingTemplate).convertAndSend(anyString(), any(ChatMessageWithFileDto.class),
+            (Map<String, Object>) any());
+    }
+
+    @Test
+    void deleteMessageTest_successfulWithFile() {
+        Long id = 1L;
+        ChatMessageWithFileDto chatMessageWithFileDto = ChatMessageWithFileDto.builder()
+            .id(id)
+            .roomId(id)
+            .senderId(id)
+            .content("Content")
+            .build();
+        ChatMessageDto messageDto = ChatMessageDto.builder()
+            .id(id)
+            .roomId(id)
+            .senderId(id)
+            .content("Content")
+            .build();
+        ChatMessage chatMessage = ChatMessage.builder()
+            .id(id)
+            .room(ChatRoom.builder().id(id).name("TestName").build())
+            .sender(Participant.builder().id(id).name("User").build())
+            .content("Content")
+            .fileName("testfile.txt")
+            .build();
+
+        when(chatMessageRepo.findById(anyLong())).thenReturn(Optional.of(chatMessage));
+        doNothing().when(chatMessageRepo).deleteById(id);
+        when(modelMapper.map(chatMessage, ChatMessageWithFileDto.class)).thenReturn(chatMessageWithFileDto);
+        doNothing().when(messagingTemplate).convertAndSend(anyString(), any(ChatMessageWithFileDto.class),
+            (Map<String, Object>) any());
+        doNothing().when(azureFileService).deleteFile("testfile.txt");
+        doNothing().when(unreadMessageRepo).deleteByMessageId(id);
+        doNothing().when(chatMessageRepo).deleteLikeFromMessageByMessageId(id);
+
+        chatMessageServiceImpl.deleteMessage(messageDto);
+
+        verify(chatMessageRepo).deleteById(id);
+        verify(azureFileService).deleteFile("testfile.txt");
+        verify(messagingTemplate).convertAndSend(anyString(), any(ChatMessageWithFileDto.class),
+            (Map<String, Object>) any());
+    }
+
+    @Test
+    void deleteMessageTest_messageNotFound() {
+        ChatMessageDto messageDto = ChatMessageDto.builder()
+            .id(1L)
+            .roomId(1L)
+            .senderId(1L)
+            .content("Content")
+            .build();
+
+        when(chatMessageRepo.findById(anyLong())).thenReturn(Optional.empty());
+
+        assertThrows(FileNotFoundException.class, () -> chatMessageServiceImpl.deleteMessage(messageDto));
+
+        verify(chatMessageRepo, never()).deleteById(anyLong());
+        verify(azureFileService, never()).deleteFile(anyString());
+        verify(messagingTemplate, never()).convertAndSend(anyString(), any(ChatMessageWithFileDto.class),
+            (Map<String, Object>) any());
+    }
+
+    @Test
+    void updateMessageTest_successful() {
+        ChatMessageWithFileDto chatMessageWithFileDto = ChatMessageWithFileDto.builder()
+            .id(1L)
+            .roomId(1L)
+            .senderId(1L)
+            .content("Updated Content")
+            .build();
+        ChatMessageDto messageDto = ChatMessageDto.builder()
+            .id(1L)
+            .roomId(1L)
+            .senderId(1L)
+            .content("Updated Content")
+            .build();
+        ChatMessage chatMessage = ChatMessage.builder()
+            .id(1L)
+            .room(ChatRoom.builder().id(1L).name("TestName").build())
+            .sender(Participant.builder().id(1L).name("User").build())
+            .content("Content")
+            .build();
+
+        when(chatMessageRepo.findById(anyLong())).thenReturn(Optional.of(chatMessage));
+        when(chatMessageRepo.save(chatMessage)).thenReturn(chatMessage);
+        when(modelMapper.map(chatMessage, ChatMessageWithFileDto.class)).thenReturn(chatMessageWithFileDto);
+        doNothing().when(messagingTemplate).convertAndSend(anyString(), any(ChatMessageWithFileDto.class),
+            (Map<String, Object>) any());
+
+        chatMessageServiceImpl.updateMessage(messageDto);
+
+        verify(chatMessageRepo).save(chatMessage);
+        verify(messagingTemplate).convertAndSend(anyString(), any(ChatMessageWithFileDto.class),
+            (Map<String, Object>) any());
+    }
+
+    @Test
+    void updateMessageTest_messageNotFound() {
+        ChatMessageDto messageDto = ChatMessageDto.builder()
+            .id(1L)
+            .roomId(1L)
+            .senderId(1L)
+            .content("Updated Content")
+            .build();
+
+        when(chatMessageRepo.findById(anyLong())).thenReturn(Optional.empty());
+
+        assertThrows(FileNotFoundException.class, () -> chatMessageServiceImpl.updateMessage(messageDto));
+
+        verify(chatMessageRepo, never()).save(any(ChatMessage.class));
+        verify(messagingTemplate, never()).convertAndSend(anyString(), any(ChatMessageWithFileDto.class),
+            (Map<String, Object>) any());
+    }
+
+    @Test
+    void updateMessageTest_emptyContent() {
+        ChatMessageDto messageDto = ChatMessageDto.builder()
+            .id(1L)
+            .roomId(1L)
+            .senderId(1L)
+            .content("")
+            .build();
+        ChatMessage chatMessage = ChatMessage.builder()
+            .id(1L)
+            .room(ChatRoom.builder().id(1L).name("TestName").build())
+            .sender(Participant.builder().id(1L).name("User").build())
+            .content("Content")
+            .build();
+
+        when(chatMessageRepo.findById(anyLong())).thenReturn(Optional.of(chatMessage));
+
+        assertThrows(ChangesNotSavedException.class, () -> chatMessageServiceImpl.updateMessage(messageDto));
+
+        verify(chatMessageRepo, never()).save(any(ChatMessage.class));
+        verify(messagingTemplate, never()).convertAndSend(anyString(), any(ChatMessageWithFileDto.class),
+            (Map<String, Object>) any());
+    }
 }


### PR DESCRIPTION
## Summary Of Changes :fire:
- The functionality of endpoints: "/chat/upload/file", "/chat/upload/voice" has been fixed and a new endpoint: "/chat/upload/image" and tests for it have been created.
- Fixed logic for processing messages with files in /app/chat/update and /app/chat/delete endpoints
- Added several fixes to the logic of adding/removing likes in a chat message
- Added Set(UserDto) likes field to ChatMessageWithFileDto to display users who liked the message
- Created UserDto to concisely display user information

## Issue Link
[#2424](https://github.com/ita-social-projects/GreenCity/issues/2424)
[#2339](https://github.com/ita-social-projects/GreenCity/issues/2339)
[#2304](https://github.com/ita-social-projects/GreenCity/issues/2304)
[#6690](https://github.com/ita-social-projects/GreenCity/issues/6690)
[#2396](https://github.com/ita-social-projects/GreenCity/issues/2396)